### PR TITLE
Add Event Filtering and Pagination Functionality

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,3 +58,5 @@ end
 gem "image_processing", "~> 1.12"
 
 gem "active_storage_validations", "~> 1.1"
+
+gem "kaminari", "~> 1.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,6 +131,18 @@ GEM
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -299,6 +311,7 @@ DEPENDENCIES
   image_processing (~> 1.12)
   importmap-rails
   jbuilder
+  kaminari (~> 1.2)
   pg
   pry-rails
   puma (>= 5.0)

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -19,4 +19,5 @@
   'components/input';
 
 @import
+  'pages/action_bar',
   'pages/event_list';

--- a/app/assets/stylesheets/pages/_action_bar.scss
+++ b/app/assets/stylesheets/pages/_action_bar.scss
@@ -1,0 +1,44 @@
+.action_bar {
+  div:first-child {
+    display: flex;
+  }
+
+  .filter {
+    display: flex;
+    flex-direction: column;
+    padding: 1rem 0;
+
+    h3 {
+      text-align: center;
+    }
+
+    form {
+      display: flex;
+      flex-direction: column;
+    }
+  }
+}
+
+@include desktop-lg{
+  .action_bar {
+    display: flex;
+    justify-content: space-between;
+
+    div:last-child {
+      margin: 0 0 0 auto;
+
+      form {
+        flex-direction: row;
+        align-items: center;
+      }
+
+      form .form-group {
+        padding: 0 1rem 0 0;
+
+        button {
+          margin: 0;
+        }
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/pages/_event_list.scss
+++ b/app/assets/stylesheets/pages/_event_list.scss
@@ -9,6 +9,6 @@
   }
 
   .btn.btn-warning {
-    width: fit-content;
+    height: 20px;
   }
 }

--- a/app/helpers/bright_events_helper.rb
+++ b/app/helpers/bright_events_helper.rb
@@ -1,2 +1,9 @@
 module BrightEventsHelper
+  def filters_action
+    if action_name != 'index'
+      user_bright_events_path
+    else
+      bright_events_path
+    end
+  end
 end

--- a/app/models/bright_event.rb
+++ b/app/models/bright_event.rb
@@ -9,4 +9,8 @@ class BrightEvent < ApplicationRecord
   belongs_to :user
 
   validates :image, content_type: { in: %w[image/jpeg image/png image/jpg], message: 'Debe ser un archivo JPEG/PNG' }
+
+  scope :all_events, -> (user) { where('privacy = ? OR user_id = ?', false, user.id) }
+  scope :filter_date, -> (from, to) { where(date: from.to_date.beginning_of_day..to.to_date.end_of_day) }
+  paginates_per 5
 end

--- a/app/views/bright_events/_action_bar.html.erb
+++ b/app/views/bright_events/_action_bar.html.erb
@@ -1,0 +1,9 @@
+<div class='action_bar'>
+  <div>
+    <%= link_to new_bright_event_path , class: 'btn btn-warning' do %>
+      <i class="uil uil-plus"></i>
+      <span>Agregar evento</span>
+    <% end %>
+  </div>
+  <%= render 'filters' %>
+</div>

--- a/app/views/bright_events/_cards_container.html.erb
+++ b/app/views/bright_events/_cards_container.html.erb
@@ -41,3 +41,4 @@
     </div>
   <% end %>
 </div>
+<%= paginate @events %>

--- a/app/views/bright_events/_filters.html.erb
+++ b/app/views/bright_events/_filters.html.erb
@@ -1,0 +1,31 @@
+<div class='filter'>
+  <h3>Filtros</h3>
+  <%= form_tag(filters_action, method: :get) do %>
+    <div class="form-group">
+      <%= label_tag 'privacy', 'Privacidad: ' %>
+      <%= select_tag 'privacy',
+                options_for_select([['Todos', 'Todos'], ['Público', false], ['Privado', true]],
+                                  params[:privacy]),
+                class: 'form-control' %>
+    </div>
+
+    <div class="form-group">
+      <%= label_tag 'date_from', 'De:' %>
+      <%= date_field_tag :date_from, 'date_from', class: 'form-control datepicker', onchange: 'updateMinDate()' %>
+    </div>
+
+    <div class="form-group">
+      <%= label_tag 'date_to', 'A:' %>
+      <%= date_field_tag :date_to, 'date_to', class: 'form-control datepicker' %>
+    </div>
+
+    <%= submit_tag 'Filtrar', class: 'btn btn-primary' %>
+  <% end %>
+
+  <script>
+    function updateMinDate() {
+      var dateFromValue = document.getElementById('date_from').value;
+      document.getElementById('date_to').min = dateFromValue;
+    }
+  </script>
+</div>

--- a/app/views/bright_events/index.html.erb
+++ b/app/views/bright_events/index.html.erb
@@ -1,8 +1,5 @@
 <div class="event-list-container">
-  <h1>Eventos Públicos</h1>
-  <%= link_to new_bright_event_path , class: 'btn btn-warning' do %>
-    <i class="uil uil-plus"></i>
-    <span>Agregar evento</span>
-  <% end %>
+  <h1>Todos los Eventos</h1>
+  <%= render 'action_bar' %>
   <%= render 'cards_container' %>
 </div>

--- a/app/views/bright_events/user_events.html.erb
+++ b/app/views/bright_events/user_events.html.erb
@@ -1,8 +1,5 @@
 <div class="event-list-container">
   <h1>Mis eventos</h1>
-  <%= link_to new_bright_event_path , class: 'btn btn-warning' do %>
-    <i class="uil uil-plus"></i>
-    <span>Agregar evento</span>
-  <% end %>
+  <%= render 'action_bar' %>
   <%= render 'cards_container' %>
 </div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -5,7 +5,7 @@
     <% end %>
   </div>
   <% if current_user %>
-    <%= link_to 'Eventos públicos', bright_events_path %>
+    <%= link_to 'Todos los eventos', bright_events_path %>
     <%= link_to 'Mis eventos', user_bright_events_path %>
     <%= link_to 'Cerrar Sesion', destroy_user_session_path, data: { turbo_method: :delete } %>
   <% else %>


### PR DESCRIPTION
## Description

This pull request introduces the ability to filter events by type and date, along with pagination for more efficient navigation within the application.

- What changes are being made?
  - Implementation of filtering logic in the backend to support event filtering by type (public or private) and date (specific date or date range).
  - Addition of user interface controls for event type and date filters on the event listing screen.
  - Pagination functionality to display a set number of events per page.

- Why are these changes necessary?
  - To enhance user experience by providing the capability to easily find and view events of interest based on type and date.
  - Pagination helps manage large volumes of events, preventing overwhelming the user interface.

## List of Changes

1. Implemented backend logic for event type and date filtering.
2. Added user interface controls for event type and date filters.
3. Integrated pagination with Kaminari gem.

## Additional Information

![Captura desde 2024-02-19 19-53-37](https://github.com/BrightCoders-Institute/s5a1-administrador-de-eventos-team-03-s5a1-administrador-de-eventos/assets/73454963/6bc5d910-7f60-43e5-82c5-fbf6de9b7b3e)

![image](https://github.com/BrightCoders-Institute/s5a1-administrador-de-eventos-team-03-s5a1-administrador-de-eventos/assets/73454963/d39f89f6-1a31-4866-ba20-0551f7ca43d3)